### PR TITLE
Optimize HuffmanArray

### DIFF
--- a/src/HuffmanTest/HuffmanArray.cs
+++ b/src/HuffmanTest/HuffmanArray.cs
@@ -10,7 +10,7 @@ namespace HuffmanTest
 {
     internal static class HuffmanArray
     {
-        private static readonly (uint code, int bitLength)[] s_encodingTable = new (uint code, int bitLength)[]
+        private static readonly (uint code, byte bitLength)[] s_encodingTable = new (uint code, byte bitLength)[]
         {
             (0b11111111_11000000_00000000_00000000, 13),
             (0b11111111_11111111_10110000_00000000, 23),
@@ -338,7 +338,7 @@ namespace HuffmanTest
                 // The longest possible symbol size is 30 bits. If we're at the last 4 bytes
                 // of the input, we need to make sure we pass the correct number of valid bits
                 // left, otherwise the trailing 0s in next may form a valid symbol.
-                var validBits = remainingBits + (edgeIndex - i) * 8;
+                var validBits = remainingBits + ((edgeIndex - i) << 3); // * 8
                 if (validBits > 30)
                     validBits = 30; // Equivalent to Math.Min(30, validBits)
 
@@ -356,10 +356,10 @@ namespace HuffmanTest
 
                 // If we crossed a byte boundary, advance i so we start at the next byte that's not fully decoded.
                 lastDecodedBits += decodedBits;
-                i += lastDecodedBits / 8;
+                i += (lastDecodedBits >> 3); // / 8
 
                 // Modulo 8 since we only care about how many bits were decoded in the last byte that we processed.
-                lastDecodedBits %= 8;
+                lastDecodedBits &= 0x7; // % 8
             }
 
             return j;
@@ -381,7 +381,7 @@ namespace HuffmanTest
             => DecodeImpl(s_decodingArray, s_encodingTable, data, validBits, out decodedBits);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int DecodeImpl(short[][] decodingArray, (uint code, int bitLength)[] encodingTable, in uint data, in int validBits, out int decodedBits)
+        private static int DecodeImpl(short[][] decodingArray, (uint code, byte bitLength)[] encodingTable, in uint data, in int validBits, out int decodedBits)
         {
             var arrayIndex = 0;
 
@@ -409,7 +409,7 @@ namespace HuffmanTest
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int DecodeImpl(short[][] decodingArray, (uint code, int bitLength)[] encodingTable, in uint workingByte, ref int arrayIndex, in int validBits, out int decodedBits)
+        private static int DecodeImpl(short[][] decodingArray, (uint code, byte bitLength)[] encodingTable, in uint workingByte, ref int arrayIndex, in int validBits, out int decodedBits)
         {
             decodedBits = 0;
 
@@ -419,7 +419,7 @@ namespace HuffmanTest
             // if the value is positive then we have a pointer into the encoding table
             if (value >= 0)
             {
-                var (_, bitLength) = encodingTable[value];
+                var bitLength = encodingTable[value].bitLength;
                 if (bitLength > validBits)
                     return -2;  // we only found a value by incorporating bits beyond the the valid remaining length of the data stream
 

--- a/src/HuffmanTest/HuffmanArray.cs
+++ b/src/HuffmanTest/HuffmanArray.cs
@@ -416,22 +416,24 @@ namespace HuffmanTest
             // key into array
             var value = decodingArray[arrayIndex][workingByte];
 
-            // if the value is positive then we have a pointer into the encoding table
-            if (value >= 0)
+            // if the value is negative then we have a pointer
+            if (value < 0)
             {
-                var bitLength = encodingTable[value].bitLength;
-                if (bitLength > validBits)
-                    return -2; // we only found a value by incorporating bits beyond the the valid remaining length of the data stream
+                // pointers are stored as negatives
+                arrayIndex = -value;
 
-                decodedBits = bitLength;
-                return value; // the index is also the value
+                // no luck. signal to caller that we could not decode
+                return -1;
             }
+            // else: value is a successful decode
 
-            // pointer to the next array will be stored as a negative
-            arrayIndex = -value;
+            // use value to index into the encoding table
+            var bitLength = encodingTable[value].bitLength;
+            if (bitLength > validBits)
+                return -2; // we only found a value by incorporating bits beyond the the valid remaining length of the data stream
 
-            // no luck. signal to caller that we could not decode
-            return -1;
+            decodedBits = bitLength;
+            return value; // the index is also the value
         }
 
         static HuffmanArray()

--- a/src/HuffmanTest/HuffmanArray.cs
+++ b/src/HuffmanTest/HuffmanArray.cs
@@ -387,8 +387,8 @@ namespace HuffmanTest
 
             // Decode in a max of 4
             // Grab data one byte at a time starting at the left
-
             // Unroll loop
+
             var value = DecodeImpl(decodingArray, encodingTable, (data >> 24) & 0xFF, ref arrayIndex, validBits, out decodedBits);
             if (value >= 0) return value;
             if (value == -2) return -1;
@@ -421,10 +421,10 @@ namespace HuffmanTest
             {
                 var bitLength = encodingTable[value].bitLength;
                 if (bitLength > validBits)
-                    return -2;  // we only found a value by incorporating bits beyond the the valid remaining length of the data stream
+                    return -2; // we only found a value by incorporating bits beyond the the valid remaining length of the data stream
 
                 decodedBits = bitLength;
-                return value;   // the index is also the value
+                return value; // the index is also the value
             }
 
             // pointer to the next array will be stored as a negative
@@ -441,8 +441,8 @@ namespace HuffmanTest
             // loop through each entry in the encoding table and create entries for it in our decoding array
             for (short i = 0; i < s_encodingTable.Length; i++)
             {
-                var (code, bitLength) = s_encodingTable[i];    // keep from having to do "s_encodingTable[i]" everywhere
-                var currentArrayIndex = 0;              // which array are we working with
+                var (code, bitLength) = s_encodingTable[i]; // keep from having to do "s_encodingTable[i]" everywhere
+                var currentArrayIndex = 0; // which array are we working with
 
                 // loop for however many bytes the value occupies
                 for (var j = 0; j <= Math.Ceiling(bitLength / 8.0); j++)
@@ -450,20 +450,20 @@ namespace HuffmanTest
                     if (s_decodingArray[currentArrayIndex] == null)
                         s_decodingArray[currentArrayIndex] = new short[256];
 
-                    var byteOffset = 8 * (3 - j);       // how many bits is the working byte offset from the right
-                    var totalLength = 8 * (j + 1);      // how many bits of the entry can consume total so far
+                    var bitOffset = 8 * (3 - j); // how many bits is the working byte offset from the right
+                    var totalBits = 8 * (j + 1); // how many bits of the entry can consume total so far
 
-                    var codeByte = (code >> byteOffset) & 0xFF;  // extract the working byte and shift it all the way to the right
+                    var codeByte = (code >> bitOffset) & 0xFF; // extract the working byte and shift it all the way to the right
 
-                    // we can finish the entry this time around. store the remaning bits and bail on the loop
-                    if (bitLength <= totalLength)
+                    // we can finish the entry this time around. store the remaining bits and bail on the loop
+                    if (bitLength <= totalBits)
                     {
                         // we need to store all permutations of the bits that are beyond the length of the code
-                        var loopMax = 0x1 << (totalLength - bitLength); // have to create entries for all of these values
+                        var loopMax = 0x1 << (totalBits - bitLength); // have to create entries for all of these values
                         for (uint k = 0; k < loopMax; k++)
-                            s_decodingArray[currentArrayIndex][codeByte + k] = i;   // each entry returns the same index into the encoding table
+                            s_decodingArray[currentArrayIndex][codeByte + k] = i; // each entry returns the same index into the encoding table
 
-                        break;  // we're done with this entry. bail on the loop
+                        break; // we're done with this entry. bail on the loop
                     }
                     // else: we need to split the entry into one or more sub-arrays
 
@@ -472,10 +472,12 @@ namespace HuffmanTest
 
                     // negative values are used as pointers to the next array. zeros are unused. positive values are a successful decode
                     if (subArrayIndex < 0)
+                    {
                         subArrayIndex = (short)-subArrayIndex;
+                    }
                     else
                     {
-                        subArrayIndex = nextAvailableSubIndex++;    // if no one has our bit battern then we'll stake our claim on the next available array
+                        subArrayIndex = nextAvailableSubIndex++; // if no one has our bit battern then we'll stake our claim on the next available array
                         s_decodingArray[currentArrayIndex][codeByte] = (short)-subArrayIndex;  // blaze the trail for the next guy
                     }
 

--- a/src/HuffmanTest/HuffmanArray.cs
+++ b/src/HuffmanTest/HuffmanArray.cs
@@ -271,7 +271,7 @@ namespace HuffmanTest
             (0b11111111_11111111_11111111_11111100, 30)
         };
 
-        public static readonly short[,] s_decodingArray = new short[15, 256];
+        public static readonly short[][] s_decodingArray = new short[15][];
 
         public static (uint encoded, int bitLength) Encode(int data) => s_encodingTable[data];
 
@@ -381,22 +381,25 @@ namespace HuffmanTest
             => DecodeImpl(s_decodingArray, s_encodingTable, data, validBits, out decodedBits);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int DecodeImpl(short[,] decodingArray, (uint code, int bitLength)[] encodingTable, in uint data, in int validBits, out int decodedBits)
+        private static int DecodeImpl(short[][] decodingArray, (uint code, int bitLength)[] encodingTable, in uint data, in int validBits, out int decodedBits)
         {
             var arrayIndex = 0;
-           
+
             // Decode in a max of 4
             // Grab data one byte at a time starting at the left
-            
+
             // Unroll loop
             var value = DecodeImpl(decodingArray, encodingTable, (data >> 24) & 0xFF, ref arrayIndex, validBits, out decodedBits);
             if (value >= 0) return value;
+            if (value == -2) return -1;
 
             value = DecodeImpl(decodingArray, encodingTable, (data >> 16) & 0xFF, ref arrayIndex, validBits, out decodedBits);
             if (value >= 0) return value;
+            if (value == -2) return -1;
 
             value = DecodeImpl(decodingArray, encodingTable, (data >> 8) & 0xFF, ref arrayIndex, validBits, out decodedBits);
             if (value >= 0) return value;
+            if (value == -2) return -1;
 
             value = DecodeImpl(decodingArray, encodingTable, (data >> 0) & 0xFF, ref arrayIndex, validBits, out decodedBits);
             if (value >= 0) return value;
@@ -406,22 +409,22 @@ namespace HuffmanTest
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int DecodeImpl(short[,] decodingArray, (uint code, int bitLength)[] encodingTable, in uint workingByte, ref int arrayIndex, in int validBits, out int decodedBits)
+        private static int DecodeImpl(short[][] decodingArray, (uint code, int bitLength)[] encodingTable, in uint workingByte, ref int arrayIndex, in int validBits, out int decodedBits)
         {
             decodedBits = 0;
 
             // key into array
-            var value = decodingArray[arrayIndex, workingByte];
+            var value = decodingArray[arrayIndex][workingByte];
 
             // if the value is positive then we have a pointer into the encoding table
-            if (value > -1)
+            if (value >= 0)
             {
                 var (_, bitLength) = encodingTable[value];
                 if (bitLength > validBits)
-                    return -1;  // we only found a value by incorporating bits beyond the the valid remaining length of the data stream
+                    return -2;  // we only found a value by incorporating bits beyond the the valid remaining length of the data stream
 
                 decodedBits = bitLength;
-                return value; // the index is also the value
+                return value;   // the index is also the value
             }
 
             // pointer to the next array will be stored as a negative
@@ -434,6 +437,7 @@ namespace HuffmanTest
         static HuffmanArray()
         {
             short nextAvailableSubIndex = 1;
+
             // loop through each entry in the encoding table and create entries for it in our decoding array
             for (short i = 0; i < s_encodingTable.Length; i++)
             {
@@ -443,6 +447,9 @@ namespace HuffmanTest
                 // loop for however many bytes the value occupies
                 for (var j = 0; j <= Math.Ceiling(bitLength / 8.0); j++)
                 {
+                    if (s_decodingArray[currentArrayIndex] == null)
+                        s_decodingArray[currentArrayIndex] = new short[256];
+
                     var byteOffset = 8 * (3 - j);       // how many bits is the working byte offset from the right
                     var totalLength = 8 * (j + 1);      // how many bits of the entry can consume total so far
 
@@ -454,14 +461,14 @@ namespace HuffmanTest
                         // we need to store all permutations of the bits that are beyond the length of the code
                         var loopMax = 0x1 << (totalLength - bitLength); // have to create entries for all of these values
                         for (uint k = 0; k < loopMax; k++)
-                            s_decodingArray[currentArrayIndex, codeByte + k] = i;   // each entry returns the same index into the encoding table
+                            s_decodingArray[currentArrayIndex][codeByte + k] = i;   // each entry returns the same index into the encoding table
 
                         break;  // we're done with this entry. bail on the loop
                     }
                     // else: we need to split the entry into one or more sub-arrays
 
                     // let's see if anyone before us has already claimed a sub-array with our bit pattern
-                    var subArrayIndex = s_decodingArray[currentArrayIndex, codeByte];
+                    var subArrayIndex = s_decodingArray[currentArrayIndex][codeByte];
 
                     // negative values are used as pointers to the next array. zeros are unused. positive values are a successful decode
                     if (subArrayIndex < 0)
@@ -469,7 +476,7 @@ namespace HuffmanTest
                     else
                     {
                         subArrayIndex = nextAvailableSubIndex++;    // if no one has our bit battern then we'll stake our claim on the next available array
-                        s_decodingArray[currentArrayIndex, codeByte] = (short)-subArrayIndex;  // blaze the trail for the next guy
+                        s_decodingArray[currentArrayIndex][codeByte] = (short)-subArrayIndex;  // blaze the trail for the next guy
                     }
 
                     currentArrayIndex = subArrayIndex;  // we've left a pointer behind us and we're moving on to the next array

--- a/src/HuffmanTest/HuffmanArray.cs
+++ b/src/HuffmanTest/HuffmanArray.cs
@@ -488,7 +488,7 @@ namespace HuffmanTest
         {
             for (var i = 0; i < s_encodingTable.Length; i++)
             {
-                (var code, var bitLength) = s_encodingTable[i];
+                var (code, bitLength) = s_encodingTable[i];
                 var decoded = Decode(code, bitLength, out var decodedBits);
                 Assert.NotEqual(-1, decoded);
                 Assert.Equal(bitLength, decodedBits);

--- a/src/HuffmanTest/HuffmanArray.cs
+++ b/src/HuffmanTest/HuffmanArray.cs
@@ -294,6 +294,8 @@ namespace HuffmanTest
 
             while (i < count)
             {
+                var remainingBits = 8 - lastDecodedBits;
+
                 var next = (uint)(src[i] << 24 + lastDecodedBits);
                 if (i + 1 < src.Length)
                 {
@@ -309,13 +311,11 @@ namespace HuffmanTest
 
                             if (i + 4 < src.Length)
                             {
-                                next |= (uint)(src[i + 4] >> (8 - lastDecodedBits));
+                                next |= (uint)(src[i + 4] >> remainingBits);
                             }
                         }
                     }
                 }
-
-                var remainingBits = 8 - lastDecodedBits;
 
                 // The remaining 7 or less bits are all 1, which is padding.
                 // We specifically check that lastDecodedBits > 0 because padding

--- a/src/HuffmanTest/HuffmanArray.cs
+++ b/src/HuffmanTest/HuffmanArray.cs
@@ -470,7 +470,9 @@ namespace HuffmanTest
                     // let's see if anyone before us has already claimed a sub-array with our bit pattern
                     var subArrayIndex = s_decodingArray[currentArrayIndex][codeByte];
 
-                    // negative values are used as pointers to the next array. zeros are unused. positive values are a successful decode
+                    // - negative values are used as pointers to the next array
+                    // 0 zeros are unused
+                    // + positive values are a successful decode
                     if (subArrayIndex < 0)
                     {
                         subArrayIndex = (short)-subArrayIndex;

--- a/src/HuffmanTest/HuffmanArray.cs
+++ b/src/HuffmanTest/HuffmanArray.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace HuffmanTest
 {
-    internal class HuffmanArray
+    internal static class HuffmanArray
     {
         private static readonly (uint code, int bitLength)[] s_encodingTable = new (uint code, int bitLength)[]
         {
@@ -285,9 +285,9 @@ namespace HuffmanTest
         /// <returns>The number of decoded symbols.</returns>
         public static int Decode(byte[] src, int offset, int count, byte[] dst)
         {
-            int i = offset;
-            int j = 0;
-            int lastDecodedBits = 0;
+            var i = offset;
+            var j = 0;
+            var lastDecodedBits = 0;
             var edgeIndex = count - 1;
             var decodingTable = s_decodingArray;
             var encodingTable = s_encodingTable;
@@ -407,7 +407,7 @@ namespace HuffmanTest
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int DecodeImpl(short[,] decodingTable, (uint code, int bitLength)[] encodingTable, in uint workingByte, ref int arrayIndex, in int validBits, out int decodedBits)
         {
-            decodedBits = 0;            
+            decodedBits = 0;
 
             // key into array
             var value = decodingTable[arrayIndex, workingByte];
@@ -429,28 +429,29 @@ namespace HuffmanTest
             return -1;
         }
 
-        public static void BuildDecodingArray()
+        static HuffmanArray()
         {
             short nextAvailableSubIndex = 1;
+
             // loop through each entry in the encoding table and create entries for it in our decoding array
             for (short i = 0; i < s_encodingTable.Length; i++)
             {
                 var (code, bitLength) = s_encodingTable[i];    // keep from having to do "s_encodingTable[i]" everywhere
-                int currentArrayIndex = 0;              // which array are we working with
+                var currentArrayIndex = 0;              // which array are we working with
 
                 // loop for however many bytes the value occupies
-                for (int j = 0; j <= Math.Ceiling(bitLength / 8.0); j++)
+                for (var j = 0; j <= Math.Ceiling(bitLength / 8.0); j++)
                 {
-                    int byteOffset = 8 * (3 - j);       // how many bits is the working byte offset from the right
-                    int totalLength = 8 * (j + 1);      // how many bits of the entry can consume total so far
+                    var byteOffset = 8 * (3 - j);       // how many bits is the working byte offset from the right
+                    var totalLength = 8 * (j + 1);      // how many bits of the entry can consume total so far
 
-                    uint codeByte = (code >> byteOffset) & 0xFF;  // extract the working byte and shift it all the way to the right
+                    var codeByte = (code >> byteOffset) & 0xFF;  // extract the working byte and shift it all the way to the right
 
                     // we can finish the entry this time around. store the remaning bits and bail on the loop
                     if (bitLength <= totalLength)
                     {
                         // we need to store all permutations of the bits that are beyond the length of the code
-                        int loopMax = 0x1 << (totalLength - bitLength); // have to create entries for all of these values
+                        var loopMax = 0x1 << (totalLength - bitLength); // have to create entries for all of these values
                         for (uint k = 0; k < loopMax; k++)
                             s_decodingArray[currentArrayIndex, codeByte + k] = i;   // each entry returns the same index into the encoding table
 
@@ -475,12 +476,12 @@ namespace HuffmanTest
             }
         }
 
-        public static void VerifyDecodingArray()
+        internal static void VerifyDecodingArray()
         {
-            for (int i = 0; i < s_encodingTable.Length; i++)
+            for (var i = 0; i < s_encodingTable.Length; i++)
             {
-                (uint code, int bitLength) = s_encodingTable[i];
-                int decoded = Decode(code, bitLength, out int decodedBits);
+                (var code, var bitLength) = s_encodingTable[i];
+                var decoded = Decode(code, bitLength, out var decodedBits);
                 Assert.NotEqual(-1, decoded);
                 Assert.Equal(bitLength, decodedBits);
                 Assert.Equal(i, decoded);

--- a/src/HuffmanTest/HuffmanBench.cs
+++ b/src/HuffmanTest/HuffmanBench.cs
@@ -94,7 +94,7 @@ namespace HuffmanTest
                 HuffmanDictOpt.s_decodingDictionary.Add(item.Key, item.Value);
 
             // build the array
-            HuffmanArray.BuildDecodingArray();
+            //HuffmanArray.BuildDecodingArray();
             HuffmanArray.VerifyDecodingArray();
 
             // prepare data to decode

--- a/src/HuffmanTest/HuffmanBench.cs
+++ b/src/HuffmanTest/HuffmanBench.cs
@@ -147,7 +147,7 @@ namespace HuffmanTest
             return sum;
         }
 
-        [Benchmark(Baseline = false, OperationsPerInvoke = (_simpleCount + _headerCount) * _iterations)]
+        //[Benchmark(Baseline = false, OperationsPerInvoke = (_simpleCount + _headerCount) * _iterations)]
         public ulong OrigOpt()
         {
             var sum = 0ul;
@@ -356,7 +356,6 @@ namespace HuffmanTest
                     }
                     else
                     {
-
                         // the next virtual dictionary is identified by the level and current working byte pattern
                         uint nextVirtualDictionaryMask =
                             nextLevel                        // next level goes in most significant byte

--- a/src/HuffmanTest/HuffmanDictOpt.cs
+++ b/src/HuffmanTest/HuffmanDictOpt.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace HuffmanTest
 {
-    public static class HuffmanDictOpt
+    internal static class HuffmanDictOpt
     {
         public readonly struct DecodingTableEntry
         {
@@ -20,7 +19,7 @@ namespace HuffmanTest
         public static readonly Dictionary<uint, DecodingTableEntry> s_decodingDictionary = new Dictionary<uint, DecodingTableEntry>(1);
 
         // TODO: this can be constructed from _decodingTable
-        private static readonly (uint code, int bitLength)[] s_encodingTable = new (uint code, int bitLength)[]
+        private static readonly (uint code, byte bitLength)[] s_encodingTable = new (uint code, byte bitLength)[]
         {
             // 0
             (0b11111111_11000000_00000000_00000000, 13),
@@ -399,7 +398,7 @@ namespace HuffmanTest
                 // The longest possible symbol size is 30 bits. If we're at the last 4 bytes
                 // of the input, we need to make sure we pass the correct number of valid bits
                 // left, otherwise the trailing 0s in next may form a valid symbol.
-                var validBits = remainingBits + (edgeIndex - i) * 8;
+                var validBits = remainingBits + ((edgeIndex - i) << 3); // * 8
                 if (validBits > 30)
                     validBits = 30; // Equivalent to Math.Min(30, validBits)
 
@@ -418,10 +417,10 @@ namespace HuffmanTest
 
                 // If we crossed a byte boundary, advance i so we start at the next byte that's not fully decoded.
                 lastDecodedBits += decodedBits;
-                i += lastDecodedBits / 8;
+                i += (lastDecodedBits >> 3); // / 8
 
                 // Modulo 8 since we only care about how many bits were decoded in the last byte that we processed.
-                lastDecodedBits %= 8;
+                lastDecodedBits &= 0x7; // % 8
             }
 
             return j;

--- a/src/HuffmanTest/HuffmanOrigOpt.cs
+++ b/src/HuffmanTest/HuffmanOrigOpt.cs
@@ -12,10 +12,10 @@ namespace HuffmanTest
     /// <summary>
     /// 
     /// </summary>
-    public static class HuffmanOrigOpt
+    internal static class HuffmanOrigOpt
     {
         // TODO: this can be constructed from _decodingTable
-        private static readonly (uint code, int bitLength)[] s_encodingTable = new (uint code, int bitLength)[]
+        private static readonly (uint code, byte bitLength)[] s_encodingTable = new (uint code, byte bitLength)[]
         {
             // 0
             (0b11111111_11000000_00000000_00000000, 13),
@@ -427,7 +427,7 @@ namespace HuffmanTest
                 // The longest possible symbol size is 30 bits. If we're at the last 4 bytes
                 // of the input, we need to make sure we pass the correct number of valid bits
                 // left, otherwise the trailing 0s in next may form a valid symbol.
-                var validBits = remainingBits + (edgeIndex - i) * 8;
+                var validBits = remainingBits + ((edgeIndex - i) << 3); // * 8
                 if (validBits > 30)
                     validBits = 30; // Equivalent to Math.Min(30, validBits)
 
@@ -445,10 +445,10 @@ namespace HuffmanTest
 
                 // If we crossed a byte boundary, advance i so we start at the next byte that's not fully decoded.
                 lastDecodedBits += decodedBits;
-                i += lastDecodedBits / 8;
+                i += (lastDecodedBits >> 3); // / 8
 
                 // Modulo 8 since we only care about how many bits were decoded in the last byte that we processed.
-                lastDecodedBits %= 8;
+                lastDecodedBits &= 0x7; // % 8
             }
 
             return j;
@@ -524,7 +524,7 @@ namespace HuffmanTest
                     var j = codes.Length - (codeMax - masked);
 
                     // Special handling for last cell (256)
-                    var is256 = j == _last - 1; 
+                    var is256 = j == _last - 1;
                     return is256 ? 256 : codes[j];
                 }
             }

--- a/src/HuffmanTest/Program.cs
+++ b/src/HuffmanTest/Program.cs
@@ -13,7 +13,7 @@ namespace HuffmanTest
             //bench.Setup();
             //for (var i = 0; i < 20_000; i++)
             //{
-            //    bench.OrigOpt();
+            //    bench.Array();
             //}
 
             //Console.WriteLine("Finished");

--- a/src/HuffmanTest/Program.cs
+++ b/src/HuffmanTest/Program.cs
@@ -7,6 +7,7 @@ namespace HuffmanTest
         static void Main(string[] args)
         {
             var bench = new HuffmanBench();
+
             var summary = BenchmarkRunner.Run<HuffmanBench>();
 
             //bench.Setup();

--- a/src/HuffmanTest/README.txt
+++ b/src/HuffmanTest/README.txt
@@ -1,5 +1,6 @@
 ﻿HuffmanOrig - NetCore original code (unchanged except for namespace)
 HuffmanOrigOpt - grant-d code (same algorithm as original, but optimized C# and lookup table)
-HuffmanDict - jbhensly code (original)
-HuffmanDictOpt - jbhensly code with grant-d optimizations
+HuffmanDict - jbhensley code (original)
+HuffmanDictOpt - jbhensley code with grant-d optimizations
 HuffmanJump - jcdickinson code (using jump-table)
+HuffmanArray - jbhensley code

--- a/src/HuffmanTest/README.txt
+++ b/src/HuffmanTest/README.txt
@@ -3,4 +3,4 @@ HuffmanOrigOpt - grant-d code (same algorithm as original, but optimized C# and 
 HuffmanDict - jbhensley code (original)
 HuffmanDictOpt - jbhensley code with grant-d optimizations
 HuffmanJump - jcdickinson code (using jump-table)
-HuffmanArray - jbhensley code
+HuffmanArray - jbhensley code with jdickinson/grant-d optimizations


### PR DESCRIPTION
Various optimizations and bug fixes.
All units pass.

```
  Method |     Mean |     Error |    StdDev | Scaled | ScaledSD | Allocated |
-------- |---------:|----------:|----------:|-------:|---------:|----------:|
    Jump | 617.3 ns |  5.430 ns |  4.814 ns |   0.67 |     0.01 |       0 B |
 OrigOpt | 731.7 ns | 14.538 ns | 24.687 ns |   0.80 |     0.03 |       0 B |
    Orig | 916.1 ns | 18.082 ns | 18.569 ns |   1.00 |     0.00 |       0 B |
   Array | 426.0 ns |  2.351 ns |  2.199 ns |   0.47 |     0.01 |       0 B |
```